### PR TITLE
Fix modern Raspberry Pi OS install and add fan curve settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Pi Fan Dashboard
+
+A lightweight Raspberry Pi PWM fan controller and web dashboard. It shows CPU temperature, fan duty, CPU use, and memory use, and now lets you edit the fan curve from the browser.
+
+This fork's installer is designed to coexist with Pi-hole and other web services: it serves itself on port `8088` and does not install nginx or alter `/var/www`.
+
+## Hardware
+
+The default wiring uses a 5 V fan with its PWM/control wire connected to physical pin 8 (`GPIO14`, BCM numbering). Power the fan from 5 V and ground. GPIO14 must not also be used by the serial console.
+
+Raspberry Pi 3 and 4 are supported through `RPi.GPIO` or the compatible `rpi-lgpio` implementation. The Raspberry Pi 5 fan header uses a different interface and is not supported by this controller.
+
+## Install
+
+```bash
+git clone https://github.com/Ai3Ui/pifandashboard.git
+cd pifandashboard
+sudo ./install.sh
+```
+
+Then open `http://PI_ADDRESS:8088/`.
+
+Options are available for a different port, GPIO, or initial fan curve:
+
+```bash
+sudo ./install.sh --port 8088 --gpio 14 --start-temp 45 --full-temp 75 --min-duty 45
+```
+
+The installer:
+
+- prefers `python3-rpi-lgpio` on current Raspberry Pi OS, with `python3-rpi.gpio` as a fallback;
+- checks whether the selected port is already occupied;
+- detects the GPIO14 serial-console conflict and gives the exact command to resolve it;
+- installs isolated services and data under `/opt/pifandashboard`, `/etc/pifandashboard`, and `/var/lib/pifandashboard`;
+- leaves nginx, Pi-hole, and `/var/www` unchanged.
+
+## Fan curve
+
+The default curve keeps the fan off below 45 °C, starts it at 45%, and increases it linearly to 100% at 75 °C. Open **Fan Settings** in the dashboard to change these values. Temperature and speed changes apply within five seconds; a GPIO change requires:
+
+```bash
+sudo systemctl restart pifandashboard-fan.service
+```
+
+## Service checks
+
+```bash
+systemctl status pifandashboard-fan.service
+systemctl status pifandashboard-web.service
+journalctl -u pifandashboard-fan.service -n 50
+```
+
+The original project documentation remains in [`docs/README.md`](docs/README.md). Licensed under the MIT License in [`docs/LICENSE`](docs/LICENSE).

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python3
+"""Dashboard, system-status API, Pi list manager, and fan-curve API."""
+
+import ipaddress
+import json
+import os
+import re
+import socket
+
+import psutil
+from flask import Flask, jsonify, request, send_from_directory
+
+BASE_DIR = os.environ.get("PIFAN_BASE", "/opt/pifandashboard")
+WEB_DIR = os.path.join(BASE_DIR, "web")
+PI_LIST_FILE = os.environ.get("PIFAN_PI_LIST", "/var/lib/pifandashboard/pi_list.json")
+CONFIG_FILE = os.environ.get("PIFAN_CONFIG", "/etc/pifandashboard/fan.json")
+STATUS_FILE = os.environ.get("PIFAN_STATUS", "/run/pifandashboard/status.json")
+NAME_PATTERN = re.compile(r"^[A-Za-z0-9 ._-]{1,40}$")
+
+app = Flask(__name__, static_folder=WEB_DIR, static_url_path="")
+
+
+@app.after_request
+def allow_status_reads(response):
+    # A dashboard can monitor another Pi without opening configuration writes.
+    if request.path == "/status" and request.method == "GET":
+        response.headers["Access-Control-Allow-Origin"] = "*"
+    return response
+
+
+def local_client():
+    try:
+        address = ipaddress.ip_address(request.remote_addr)
+        return address.is_private or address.is_loopback
+    except ValueError:
+        return False
+
+
+def read_json(path, fallback):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return fallback
+
+
+def write_json(path, value):
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2)
+        handle.write("\n")
+    os.replace(temporary, path)
+
+
+def valid_pi(data):
+    try:
+        return (
+            NAME_PATTERN.fullmatch(str(data.get("name", ""))) is not None
+            and ipaddress.ip_address(data.get("ip", "")).version == 4
+            and 1024 <= int(data.get("port", 0)) <= 65535
+        )
+    except (ValueError, TypeError):
+        return False
+
+
+def normalize_config(data):
+    try:
+        config = {
+            "gpio": int(data.get("gpio", 14)),
+            "start_temp": float(data["start_temp"]),
+            "full_temp": float(data["full_temp"]),
+            "min_duty": int(data["min_duty"]),
+        }
+    except (KeyError, TypeError, ValueError):
+        return None
+    if not (2 <= config["gpio"] <= 27):
+        return None
+    if not (20 <= config["start_temp"] <= 75):
+        return None
+    if not (config["start_temp"] + 5 <= config["full_temp"] <= 90):
+        return None
+    if not (20 <= config["min_duty"] <= 100):
+        return None
+    return config
+
+
+@app.get("/")
+def index():
+    return send_from_directory(WEB_DIR, "index.html")
+
+
+@app.get("/status")
+def status():
+    fan = read_json(STATUS_FILE, {})
+    if "temperature" not in fan:
+        return jsonify(error="fan controller has not reported yet"), 503
+    return jsonify(
+        temperature=fan["temperature"],
+        speed=fan["speed"],
+        cpu=psutil.cpu_percent(interval=0.2),
+        memory=psutil.virtual_memory().percent,
+        hostname=socket.gethostname(),
+    )
+
+
+@app.get("/get_pi_list")
+def get_pi_list():
+    return jsonify(read_json(PI_LIST_FILE, []))
+
+
+@app.post("/add_pi")
+def add_pi():
+    if not local_client():
+        return jsonify(error="local network only"), 403
+    data = request.get_json(silent=True) or {}
+    if not valid_pi(data):
+        return jsonify(error="invalid Pi details"), 400
+    entry = {"name": data["name"], "ip": data["ip"], "port": int(data["port"])}
+    pis = read_json(PI_LIST_FILE, [])
+    if any(pi["ip"] == entry["ip"] for pi in pis):
+        return jsonify(error="IP already exists"), 409
+    pis.append(entry)
+    write_json(PI_LIST_FILE, pis)
+    return jsonify(status="added"), 201
+
+
+@app.post("/edit_pi")
+def edit_pi():
+    if not local_client():
+        return jsonify(error="local network only"), 403
+    data = request.get_json(silent=True) or {}
+    replacement = {"name": data.get("name"), "ip": data.get("ip"), "port": data.get("port")}
+    if not data.get("originalIp") or not valid_pi(replacement):
+        return jsonify(error="invalid Pi details"), 400
+    replacement["port"] = int(replacement["port"])
+    pis = read_json(PI_LIST_FILE, [])
+    for index, pi in enumerate(pis):
+        if pi["ip"] == data["originalIp"]:
+            pis[index] = replacement
+            write_json(PI_LIST_FILE, pis)
+            return jsonify(status="updated")
+    return jsonify(error="original IP not found"), 404
+
+
+@app.post("/delete_pi")
+def delete_pi():
+    if not local_client():
+        return jsonify(error="local network only"), 403
+    target = (request.get_json(silent=True) or {}).get("ip")
+    pis = [pi for pi in read_json(PI_LIST_FILE, []) if pi.get("ip") != target]
+    write_json(PI_LIST_FILE, pis)
+    return jsonify(status="deleted")
+
+
+@app.get("/fan-config")
+def get_fan_config():
+    return jsonify(read_json(CONFIG_FILE, {}))
+
+
+@app.put("/fan-config")
+def put_fan_config():
+    if not local_client():
+        return jsonify(error="local network only"), 403
+    config = normalize_config(request.get_json(silent=True) or {})
+    if config is None:
+        return jsonify(error="invalid fan curve"), 400
+    write_json(CONFIG_FILE, config)
+    return jsonify(config)
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PIFAN_PORT", "8088"))
+    app.run(host="0.0.0.0", port=port, debug=False)

--- a/app/fan_control.py
+++ b/app/fan_control.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+"""PWM fan controller with a reloadable JSON fan curve."""
+
+import json
+import os
+import signal
+import time
+
+import RPi.GPIO as GPIO
+
+CONFIG_FILE = os.environ.get("PIFAN_CONFIG", "/etc/pifandashboard/fan.json")
+STATUS_FILE = os.environ.get("PIFAN_STATUS", "/run/pifandashboard/status.json")
+PWM_FREQUENCY = 100
+DEFAULT_CONFIG = {"gpio": 14, "start_temp": 45.0, "full_temp": 75.0, "min_duty": 45}
+
+
+def load_config():
+    try:
+        with open(CONFIG_FILE, encoding="utf-8") as handle:
+            config = {**DEFAULT_CONFIG, **json.load(handle)}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        config = DEFAULT_CONFIG.copy()
+    return config
+
+
+def cpu_temperature():
+    with open("/sys/class/thermal/thermal_zone0/temp", encoding="ascii") as handle:
+        return int(handle.read().strip()) / 1000.0
+
+
+def requested_duty(temp, config):
+    start = float(config["start_temp"])
+    full = float(config["full_temp"])
+    minimum = int(config["min_duty"])
+    if temp < start:
+        return 0
+    if temp >= full:
+        return 100
+    fraction = (temp - start) / (full - start)
+    return round(minimum + fraction * (100 - minimum))
+
+
+def write_status(temp, duty, config):
+    temporary = STATUS_FILE + ".tmp"
+    payload = {
+        "temperature": round(temp, 1),
+        "speed": duty,
+        "gpio": int(config["gpio"]),
+    }
+    with open(temporary, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+    os.chmod(temporary, 0o644)
+    os.replace(temporary, STATUS_FILE)
+
+
+def main():
+    GPIO.setwarnings(False)
+    GPIO.setmode(GPIO.BCM)
+    config = load_config()
+    gpio = int(config["gpio"])
+    GPIO.setup(gpio, GPIO.OUT, initial=GPIO.LOW)
+    fan = GPIO.PWM(gpio, PWM_FREQUENCY)
+    fan.start(0)
+    running = True
+
+    def stop(_signum, _frame):
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    try:
+        while running:
+            current = load_config()
+            if int(current["gpio"]) != gpio:
+                # A GPIO change is applied after the service is restarted by the API.
+                current["gpio"] = gpio
+            temperature = cpu_temperature()
+            duty = requested_duty(temperature, current)
+            fan.ChangeDutyCycle(duty)
+            write_status(temperature, duty, current)
+            time.sleep(5)
+    finally:
+        fan.ChangeDutyCycle(100)
+        fan.stop()
+        GPIO.cleanup(gpio)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+PORT=8088
+GPIO=14
+START_TEMP=45
+FULL_TEMP=75
+MIN_DUTY=45
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  echo "Usage: sudo ./install.sh [--port 8088] [--gpio 14] [--start-temp 45] [--full-temp 75] [--min-duty 45]"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port) PORT="$2"; shift 2 ;;
+    --gpio) GPIO="$2"; shift 2 ;;
+    --start-temp) START_TEMP="$2"; shift 2 ;;
+    --full-temp) FULL_TEMP="$2"; shift 2 ;;
+    --min-duty) MIN_DUTY="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "Run this installer with sudo." >&2
+  exit 1
+fi
+if [[ ! "$PORT" =~ ^[0-9]+$ ]] || (( PORT < 1024 || PORT > 65535 )); then
+  echo "Port must be between 1024 and 65535." >&2
+  exit 2
+fi
+if ss -ltnH "sport = :$PORT" | grep -q . && ! systemctl is-active --quiet pifandashboard-web.service; then
+  echo "Port $PORT is already in use. Choose another with --port." >&2
+  exit 1
+fi
+if grep -qE '(^| )console=(serial0|ttyAMA0|ttyS0),' /proc/cmdline && [[ "$GPIO" == "14" ]]; then
+  echo "GPIO14 is being used by the serial console. Disable it with 'sudo raspi-config nonint do_serial 1', then reboot." >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y python3-flask python3-psutil rsync
+if apt-cache show python3-rpi-lgpio >/dev/null 2>&1; then
+  apt-get install -y python3-rpi-lgpio
+else
+  apt-get install -y python3-rpi.gpio
+fi
+
+id pifandashboard >/dev/null 2>&1 || useradd --system --home /nonexistent --shell /usr/sbin/nologin pifandashboard
+install -d -m 0755 /opt/pifandashboard/app /opt/pifandashboard/web
+install -d -o pifandashboard -g pifandashboard -m 0755 /var/lib/pifandashboard
+install -d -o root -g pifandashboard -m 0775 /etc/pifandashboard
+install -m 0755 "$SOURCE_DIR/app/fan_control.py" "$SOURCE_DIR/app/dashboard.py" /opt/pifandashboard/app/
+rsync -a --delete "$SOURCE_DIR/webinterface/fandashboard/" /opt/pifandashboard/web/
+chmod -R u=rwX,go=rX /opt/pifandashboard
+
+if [[ ! -f /var/lib/pifandashboard/pi_list.json ]]; then
+  PI_IP="$(hostname -I | awk '{print $1}')"
+  printf '[{"name":"%s","ip":"%s","port":%s}]\n' "$(hostname)" "$PI_IP" "$PORT" >/var/lib/pifandashboard/pi_list.json
+fi
+chown pifandashboard:pifandashboard /var/lib/pifandashboard/pi_list.json
+if [[ ! -f /etc/pifandashboard/fan.json ]]; then
+  printf '{"gpio":%s,"start_temp":%s,"full_temp":%s,"min_duty":%s}\n' "$GPIO" "$START_TEMP" "$FULL_TEMP" "$MIN_DUTY" >/etc/pifandashboard/fan.json
+fi
+chown root:pifandashboard /etc/pifandashboard/fan.json
+chmod 0664 /etc/pifandashboard/fan.json
+
+install -m 0644 "$SOURCE_DIR/systemd/pifandashboard-fan.service" /etc/systemd/system/
+sed "s/Environment=PIFAN_PORT=.*/Environment=PIFAN_PORT=$PORT/" "$SOURCE_DIR/systemd/pifandashboard-web.service" >/etc/systemd/system/pifandashboard-web.service
+chmod 0644 /etc/systemd/system/pifandashboard-web.service
+systemctl daemon-reload
+systemctl enable --now pifandashboard-fan.service pifandashboard-web.service
+systemctl restart pifandashboard-fan.service pifandashboard-web.service
+
+echo "Pi Fan Dashboard is running at http://$(hostname -I | awk '{print $1}'):$PORT/"
+echo "This installer did not install or change nginx, Pi-hole, or /var/www."

--- a/systemd/pifandashboard-fan.service
+++ b/systemd/pifandashboard-fan.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Pi Fan Dashboard PWM controller
+After=local-fs.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /opt/pifandashboard/app/fan_control.py
+Restart=on-failure
+RestartSec=3
+User=root
+RuntimeDirectory=pifandashboard
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/pifandashboard-web.service
+++ b/systemd/pifandashboard-web.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Pi Fan Dashboard web interface
+After=network.target pifandashboard-fan.service
+Requires=pifandashboard-fan.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /opt/pifandashboard/app/dashboard.py
+Restart=on-failure
+RestartSec=3
+User=pifandashboard
+Group=pifandashboard
+Environment=PIFAN_PORT=8088
+Environment=PYTHONDONTWRITEBYTECODE=1
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/etc/pifandashboard /var/lib/pifandashboard
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+class DashboardApiTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        psutil = types.ModuleType("psutil")
+        psutil.cpu_percent = lambda interval=0: 0
+        psutil.virtual_memory = lambda: types.SimpleNamespace(percent=0)
+        sys.modules.setdefault("psutil", psutil)
+        cls.temporary = tempfile.TemporaryDirectory()
+        base = Path(cls.temporary.name)
+        os.environ["PIFAN_BASE"] = str(base)
+        os.environ["PIFAN_PI_LIST"] = str(base / "pi_list.json")
+        os.environ["PIFAN_CONFIG"] = str(base / "fan.json")
+        os.environ["PIFAN_STATUS"] = str(base / "status.json")
+        (base / "pi_list.json").write_text("[]", encoding="utf-8")
+        (base / "fan.json").write_text(
+            json.dumps({"gpio": 14, "start_temp": 45, "full_temp": 75, "min_duty": 45}),
+            encoding="utf-8",
+        )
+        spec = importlib.util.spec_from_file_location(
+            "dashboard", Path(__file__).parents[1] / "app" / "dashboard.py"
+        )
+        cls.dashboard = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.dashboard)
+        cls.client = cls.dashboard.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.temporary.cleanup()
+
+    def test_reads_fan_config(self):
+        response = self.client.get("/fan-config")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["start_temp"], 45)
+
+    def test_updates_valid_fan_curve(self):
+        response = self.client.put(
+            "/fan-config",
+            json={"gpio": 14, "start_temp": 50, "full_temp": 70, "min_duty": 40},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["full_temp"], 70)
+
+    def test_rejects_curve_with_no_ramp(self):
+        response = self.client.put(
+            "/fan-config",
+            json={"gpio": 14, "start_temp": 60, "full_temp": 62, "min_duty": 40},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_rejects_public_configuration_write(self):
+        response = self.client.put(
+            "/fan-config",
+            json={"gpio": 14, "start_temp": 45, "full_temp": 75, "min_duty": 45},
+            environ_base={"REMOTE_ADDR": "8.8.8.8"},
+        )
+        self.assertEqual(response.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -1,0 +1,39 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+gpio = types.ModuleType("RPi.GPIO")
+rpi = types.ModuleType("RPi")
+rpi.GPIO = gpio
+sys.modules.setdefault("RPi", rpi)
+sys.modules.setdefault("RPi.GPIO", gpio)
+
+spec = importlib.util.spec_from_file_location(
+    "fan_control", Path(__file__).parents[1] / "app" / "fan_control.py"
+)
+fan_control = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fan_control)
+
+
+class FanCurveTests(unittest.TestCase):
+    def setUp(self):
+        self.config = {"start_temp": 45, "full_temp": 75, "min_duty": 45}
+
+    def test_fan_is_off_below_start_temperature(self):
+        self.assertEqual(fan_control.requested_duty(44.9, self.config), 0)
+
+    def test_fan_starts_at_minimum_duty(self):
+        self.assertEqual(fan_control.requested_duty(45, self.config), 45)
+
+    def test_fan_reaches_full_duty(self):
+        self.assertEqual(fan_control.requested_duty(75, self.config), 100)
+
+    def test_fan_curve_is_linear(self):
+        self.assertEqual(fan_control.requested_duty(60, self.config), 72)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webinterface/fandashboard/index.html
+++ b/webinterface/fandashboard/index.html
@@ -39,6 +39,9 @@
     <h1 class="mb-4"><i class="bi bi-speedometer2"></i> Raspberry Pi Fan Status</h1>
     <div id="countdown-desktop" class="position-absolute top-0 end-0 d-none d-md-block" style="margin-right: 0.75rem;">
       <div class="d-flex align-items-center gap-2">
+        <button class="btn btn-info btn-lg" data-bs-toggle="modal" data-bs-target="#fanSettingsModal">
+          <i class="bi bi-fan me-1"></i>Fan Settings
+        </button>
         <button class="btn btn-warning btn-lg" data-bs-toggle="modal" data-bs-target="#piListModal">
           <i class="bi bi-pencil-square me-1"></i>Edit Pi List
         </button>
@@ -48,6 +51,9 @@
       </div>
     </div>
     <div id="countdown-mobile" class="d-block d-md-none my-3">
+      <button class="btn btn-info btn-sm" data-bs-toggle="modal" data-bs-target="#fanSettingsModal">
+        <i class="bi bi-fan me-1"></i>Fan Settings
+      </button>
       <button class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#piListModal">
         <i class="bi bi-pencil-square me-1"></i>Edit Pi List
       </button>
@@ -94,6 +100,43 @@
         <small class="text-muted">Not affiliated with Raspberry Pi Ltd</small>
       </span>
     </footer>
+  </div>
+  <!-- Fan Settings Modal -->
+  <div class="modal fade" id="fanSettingsModal" tabindex="-1" aria-labelledby="fanSettingsModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content bg-dark text-white">
+        <div class="modal-header">
+          <h5 class="modal-title" id="fanSettingsModalLabel"><i class="bi bi-fan me-2"></i>Fan Curve</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div id="fanConfigAlert" class="alert d-none" role="alert"></div>
+          <div class="row g-3">
+            <div class="col-6">
+              <label for="fanStartTemp" class="form-label">Fan starts at (°C)</label>
+              <input type="number" class="form-control" id="fanStartTemp" min="20" max="75" step="1">
+            </div>
+            <div class="col-6">
+              <label for="fanFullTemp" class="form-label">Full speed at (°C)</label>
+              <input type="number" class="form-control" id="fanFullTemp" min="25" max="90" step="1">
+            </div>
+            <div class="col-6">
+              <label for="fanMinDuty" class="form-label">Starting speed (%)</label>
+              <input type="number" class="form-control" id="fanMinDuty" min="20" max="100" step="1">
+            </div>
+            <div class="col-6">
+              <label for="fanGpio" class="form-label">PWM GPIO (BCM)</label>
+              <input type="number" class="form-control" id="fanGpio" min="2" max="27" step="1">
+            </div>
+          </div>
+          <p class="text-secondary small mt-3 mb-0">GPIO changes take effect after restarting the fan service. Other values apply automatically.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-success" id="saveFanConfig">Save Fan Curve</button>
+        </div>
+      </div>
+    </div>
   </div>
   <!-- Pi List Modal -->
   <div class="modal fade" id="piListModal" tabindex="-1" aria-labelledby="piListModalLabel" aria-hidden="true">

--- a/webinterface/fandashboard/js/script.js
+++ b/webinterface/fandashboard/js/script.js
@@ -16,7 +16,8 @@
   License: MIT
 */
 
-const flaskPort = ${PI_MANAGER_PORT}; // Port of your Flask Pi Manager API
+// Manager endpoints are served by the same Flask process as this page.
+const managerUrl = (path) => new URL(path, window.location.href).toString();
 let pis = []; // Global list for dashboard + modal
 let justAddedOfflineIp = null;
 let currentlyEditingItem = null;
@@ -56,7 +57,7 @@ function formatIpInput(evt) {
 // Load from Flask JSON endpoint
 async function loadPiList() {
   try {
-    const response = await fetch(`http://${window.location.hostname}:${flaskPort}/get_pi_list`);
+    const response = await fetch(managerUrl("/get_pi_list"));
     const data = await response.json();
     pis = data;
     renderPiList();
@@ -187,7 +188,7 @@ function handleEditMode(li, pi) {
 // This function posts the updated Pi data to the '/edit_pi' endpoint.
 async function editPi(originalIp, updatedPi) {
   try {
-    const response = await fetch(`http://${window.location.hostname}:${flaskPort}/edit_pi`, {
+    const response = await fetch(managerUrl("/edit_pi"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ originalIp, ...updatedPi })
@@ -326,7 +327,7 @@ async function addPi() {
 
   // POST to add_pi regardless of reachability (UI will reflect error state)
   try {
-    const response = await fetch(`http://${window.location.hostname}:${flaskPort}/add_pi`, {
+    const response = await fetch(managerUrl("/add_pi"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, ip, port })
@@ -398,7 +399,7 @@ function clearAlert() {
 // Delete Pi by IP
 async function deletePi(ip) {
   try {
-    const response = await fetch(`http://${window.location.hostname}:${flaskPort}/delete_pi`, {
+    const response = await fetch(managerUrl("/delete_pi"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ip })
@@ -820,4 +821,50 @@ window.addEventListener("DOMContentLoaded", async () => {
     addIpInput.dataset.prevIp = '';
     addIpInput.addEventListener("input", formatIpInput);
   }
+
+  const fanSettingsModal = document.getElementById("fanSettingsModal");
+  if (fanSettingsModal) fanSettingsModal.addEventListener("show.bs.modal", loadFanConfig);
+  const saveFanConfigButton = document.getElementById("saveFanConfig");
+  if (saveFanConfigButton) saveFanConfigButton.addEventListener("click", saveFanConfig);
 });
+
+async function loadFanConfig() {
+  const alertBox = document.getElementById("fanConfigAlert");
+  alertBox.className = "alert d-none";
+  try {
+    const response = await fetch(managerUrl("/fan-config"));
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const config = await response.json();
+    document.getElementById("fanGpio").value = config.gpio;
+    document.getElementById("fanStartTemp").value = config.start_temp;
+    document.getElementById("fanFullTemp").value = config.full_temp;
+    document.getElementById("fanMinDuty").value = config.min_duty;
+  } catch (error) {
+    alertBox.className = "alert alert-danger";
+    alertBox.textContent = `Could not load fan settings: ${error.message}`;
+  }
+}
+
+async function saveFanConfig() {
+  const alertBox = document.getElementById("fanConfigAlert");
+  const config = {
+    gpio: Number(document.getElementById("fanGpio").value),
+    start_temp: Number(document.getElementById("fanStartTemp").value),
+    full_temp: Number(document.getElementById("fanFullTemp").value),
+    min_duty: Number(document.getElementById("fanMinDuty").value)
+  };
+  try {
+    const response = await fetch(managerUrl("/fan-config"), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config)
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || `HTTP ${response.status}`);
+    alertBox.className = "alert alert-success";
+    alertBox.textContent = "Fan curve saved. Temperature and duty changes apply within five seconds.";
+  } catch (error) {
+    alertBox.className = "alert alert-danger";
+    alertBox.textContent = `Could not save fan settings: ${error.message}`;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-hosted Flask dashboard that avoids nginx, Pi-hole, and /var/www conflicts
- use python3-rpi-lgpio on current Raspberry Pi OS with an RPi.GPIO fallback
- add validated browser-based fan curve configuration
- install hardened, correctly ordered systemd services
- add fan-curve and API tests

## Validation
- 8 unit/API tests pass on Raspberry Pi OS (Debian Trixie)
- bash and JavaScript syntax checks pass
- installed and verified on a Raspberry Pi 3B+: dashboard, static assets, status/config APIs, service startup, and Pi-hole all healthy

This is intentionally a draft because it replaces the legacy multi-process/nginx installation path with a simpler self-contained service.